### PR TITLE
Use index.js on javascript package

### DIFF
--- a/src/wasm/test/README.md
+++ b/src/wasm/test/README.md
@@ -12,7 +12,7 @@ and cannot work without https unless testing on localhost.
 
 * Build with [multithreading](https://github.com/GoogleChromeLabs/wasm-bindgen-rayon)
 ```
-RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-rustup run nightly-2022-04-07 wasm-pack build --release --target web 
---features=wasmtest,wasmrayon -- -Z build-std=panic_abort,std  \
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \ 
+rustup run nightly-2022-04-07 wasm-pack build --out-name index --release \ 
+--target web --features=wasmtest,wasmrayon -- -Z build-std=panic_abort,std
 ```

--- a/src/wasm/test/example.js
+++ b/src/wasm/test/example.js
@@ -1,4 +1,4 @@
-import init, {ex} from "../../../pkg/strand.js";
+import init, {ex} from "../../../pkg/index.js";
 init()
 .then(() => {
     const bytes = new Uint8Array([1,99,226,99]);

--- a/src/wasm/test/test_noworker.html
+++ b/src/wasm/test/test_noworker.html
@@ -6,7 +6,7 @@
   </head>
   <body style="background-color:black;">
     <script type="module">
-    import init, {test} from '../../../pkg/strand.js';
+    import init, {test} from '../../../pkg/index.js';
     
         async function run() {
             await init();

--- a/src/wasm/test/worker.js
+++ b/src/wasm/test/worker.js
@@ -1,4 +1,4 @@
-import * as pkg from "../../../pkg/strand.js";
+import * as pkg from "../../../pkg/index.js";
 pkg.default().then(_ => {
     var parameters = {}
     location.search.slice(1).split("&").forEach( function(key_value) { var kv = key_value.split("="); parameters[kv[0]] = kv[1]; });

--- a/src/wasm/test/worker_t.js
+++ b/src/wasm/test/worker_t.js
@@ -1,5 +1,5 @@
 import "./fd.js";
-import * as pkg from "../../../pkg_t/strand.js";
+import * as pkg from "../../../pkg_t/index.js";
 pkg.default().then(_ => {
     var parameters = {}
     location.search.slice(1).split("&").forEach( function(key_value) { var kv = key_value.split("="); parameters[kv[0]] = kv[1]; });


### PR DESCRIPTION
Compile to index.js to use standard npm package format.