### PR TITLE
Make BigUintX/E tuple args public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 /__pycache__/
 rust-toolchain
+# VS Code
+.DS_Store

--- a/src/backend/numb.rs
+++ b/src/backend/numb.rs
@@ -285,9 +285,9 @@ impl BigintCtxParams for P2048 {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct BigUintE(BigUint);
+pub struct BigUintE(pub BigUint);
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct BigUintX(BigUint);
+pub struct BigUintX(pub BigUint);
 
 impl ToByteTree for BigUintE {
     fn to_byte_tree(&self) -> ByteTree {


### PR DESCRIPTION
See [this](https://stackoverflow.com/questions/24110970/tuple-struct-constructor-complains-about-private-fields).