### PR TITLE
making bots less verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,5 +198,6 @@ jobs:
           output-file-path: ./output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./cache/benchmark-data.json
-          comment-always: true
+          alert-threshold: '150%'
+          comment-on-alert: true
           fail-on-alert: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022 Eduardo Robles <edu@sequentech.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+# Codecov repository config file
+# https://docs.codecov.com/docs/codecov-yaml#repository-yaml
+comment:
+  # only post a comment on a PR if the code coverage changes
+  # https://docs.codecov.com/docs/codecovyml-reference#comment
+  require_changes: true


### PR DESCRIPTION
- make codecov comment in a PR only on coverage changes
- make benchmark-action comment in a PR (actually, in a commit for now)
  if benchmark worsens noticably (50% worse)