### PR TITLE
cachix: changing the binary cache to sequent's organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: cachix/cachix-action@v10
       with:
-        name: sequent-tech
+        name: sequentech
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Run unit tests
@@ -225,7 +225,7 @@ jobs:
 
     - uses: cachix/cachix-action@v10
       with:
-        name: sequent-tech
+        name: sequentech
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     # not running this command in https://github.com/nektos/act
@@ -263,7 +263,7 @@ jobs:
 
     - uses: cachix/cachix-action@v10
       with:
-        name: sequent-tech
+        name: sequentech
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Build the flake


### PR DESCRIPTION
- The previous cache name and reference was related to a private cache from @Findeton and not the organization's cachix cache. 