### PR TITLE
Multiple targets on nix flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ This repository doesn´t include a `Cargo.lock` file as it is intended to work a
 
 ## building
 
+This project uses [nix](https://nixos.org/) to create reproducible builds. In order to build the project as a library for the host system, run:
+
+```nix build```
+
+You can build the project as a WASM library with:
+
+```nix build .#strand-wasm```
+
+If you don't want to use nix, you can build the project with:
+
 ```cargo build```
 
 ### Build with parallelism

--- a/flake.nix
+++ b/flake.nix
@@ -16,29 +16,34 @@
           inherit system overlays;
         };
         stdenv = pkgs.clangStdenv;
-        rust-wasm = pkgs
+        configureRustTargets = targets : pkgs
           .rust-bin
           .nightly
           ."2022-04-07"
           .default
           .override {
               extensions = [ "rust-src" ];
-              targets = [ "wasm32-unknown-unknown" ];
-          }
-        ;
-        rust-system = pkgs
-          .rust-bin
-          .nightly
-          ."2022-04-07"
-          .default
-          .override {
-              extensions = [ "rust-src" ];
-          }
-        ;
+               ${if (builtins.length targets) > 0 then "targets" else null} = targets;
+
+          };
+        rust-wasm = configureRustTargets [ "wasm32-unknown-unknown" ];
+        rust-system  = configureRustTargets [];
+        # see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file
+        cargoPatches = {
+            cargoLock = let
+                fixupLockFile = path: (builtins.readFile path);
+            in {
+                lockFileContents = fixupLockFile ./Cargo.lock.copy;
+            };
+            postPatch = ''
+                cp ${./Cargo.lock.copy} Cargo.lock
+            '';
+        };
+        buildRustPackageWithCargo = cargoArgs: pkgs.rustPlatform.buildRustPackage (cargoPatches // cargoArgs);
       in rec {
-        packages.strand-wasm = pkgs.rustPlatform.buildRustPackage {
+        packages.strand-wasm = buildRustPackageWithCargo {
           pname = "strand-wasm";
-          version = "0.0.3";
+          version = "0.0.1";
           src = ./.;
           nativeBuildInputs = [
             rust-wasm
@@ -59,35 +64,15 @@
             rm -Rf $out/temp_home
             cp pkg/strand-*.tgz $out
             ";
-
-            # see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file
-            cargoLock = let
-                fixupLockFile = path: (builtins.readFile path);
-            in {
-                lockFileContents = fixupLockFile ./Cargo.lock.copy;
-            };
-            postPatch = ''
-                cp ${./Cargo.lock.copy} Cargo.lock
-            '';
         };
-        packages.strand-system = pkgs.rustPlatform.buildRustPackage {
-          pname = "strand-system";
-          version = "0.0.2";
+        packages.strand-lib = buildRustPackageWithCargo {
+          pname = "strand-lib";
+          version = "0.0.1";
           src = ./.;
           nativeBuildInputs = [
             rust-system
           ];
-
-            # see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file
-            cargoLock = let
-                fixupLockFile = path: (builtins.readFile path);
-            in {
-                lockFileContents = fixupLockFile ./Cargo.lock.copy;
-            }; 
-            postPatch = ''
-                cp ${./Cargo.lock.copy} Cargo.lock
-            '';
-        }; 
+        };
         defaultPackage = self.packages.${system}.strand-wasm;
 
         # configure the dev shell

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           inherit system overlays;
         };
         stdenv = pkgs.clangStdenv;
-        rust-nightly = pkgs
+        rust-wasm = pkgs
           .rust-bin
           .nightly
           ."2022-04-07"
@@ -26,13 +26,22 @@
               targets = [ "wasm32-unknown-unknown" ];
           }
         ;
+        rust-system = pkgs
+          .rust-bin
+          .nightly
+          ."2022-04-07"
+          .default
+          .override {
+              extensions = [ "rust-src" ];
+          }
+        ;
       in rec {
-        defaultPackage = pkgs.rustPlatform.buildRustPackage {
-          pname = "strand";
-          version = "0.0.1";
+        packages.strand-wasm = pkgs.rustPlatform.buildRustPackage {
+          pname = "strand-wasm";
+          version = "0.0.3";
           src = ./.;
           nativeBuildInputs = [
-            rust-nightly
+            rust-wasm
             pkgs.nodePackages.npm
             pkgs.wasm-pack
             pkgs.wasm-bindgen-cli
@@ -61,6 +70,25 @@
                 cp ${./Cargo.lock.copy} Cargo.lock
             '';
         };
+        packages.strand-system = pkgs.rustPlatform.buildRustPackage {
+          pname = "strand-system";
+          version = "0.0.2";
+          src = ./.;
+          nativeBuildInputs = [
+            rust-system
+          ];
+
+            # see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file
+            cargoLock = let
+                fixupLockFile = path: (builtins.readFile path);
+            in {
+                lockFileContents = fixupLockFile ./Cargo.lock.copy;
+            }; 
+            postPatch = ''
+                cp ${./Cargo.lock.copy} Cargo.lock
+            '';
+        }; 
+        defaultPackage = self.packages.${system}.strand-wasm;
 
         # configure the dev shell
         devShell = (


### PR DESCRIPTION
# Changes
* Tidy up the flake to avoid duplicate code.
* Add a `strand-lib` package to the flake to build the project as a standard library (rather than for wasm).
* Update Readme to describe how to build the project with nix and for the wasm target.